### PR TITLE
Proper way to get global

### DIFF
--- a/res/globals.js
+++ b/res/globals.js
@@ -1,6 +1,6 @@
 /*jshint undef: false*/
 (function () {
-    var global = this;
+    var global = Function('return this')();
     var exportApiObjectKey = '__EXPORT_API_OBJECT__';
     var map = __MAP__;
     if (global[exportApiObjectKey]) {


### PR DESCRIPTION
This code could be used in any environment. In strict mode `this` will be `undefined`. This change allows get proper global reference.